### PR TITLE
Use Map for apps list; Fix various minor issues/errors

### DIFF
--- a/src/managers/tray.ts
+++ b/src/managers/tray.ts
@@ -24,12 +24,12 @@ export class TrayManager {
   constructor() {
     this.tray = new Tray(trayIcon);
     this.tray.setToolTip(app.name);
-    this.tray.on('right-click', () => this.update());
-    this.tray.on('click', () => win.show());
+    this.tray.on('right-click', () => win && this.update());
+    this.tray.on('click', () => win && win.show());
   }
 
   update(): void {
-    this.tray.setContextMenu(
+    this.tray.popUpContextMenu(
       Menu.buildFromTemplate([
         {
           icon:

--- a/src/steam.ts
+++ b/src/steam.ts
@@ -61,8 +61,7 @@ export let userName: string = null;
 export let userAvatar: string = null;
 export let accountName: string = null;
 export let steamID: string = null;
-export let apps: any = null;
-// export let apps: Array<OwnedApp> = null;
+export let apps: Map<string, { appid: string; name: string; img_icon_url?: string; }> | null = null;
 export let activeGame: MinimalGamePresence = null;
 export let steamGuardAvailable = true;
 
@@ -147,14 +146,15 @@ user.on('user', async (sid, data) => {
     while (apps === null) await wait(500);
 
     const app = apps.get(data.game_played_app_id);
+    const appid = data.game_played_app_id;
 
     if (!app) {
       activeGame = { appID: 0, presence: [], presenceString: null };
       emitter.emit('presence', activeGame);
-      presenceLogger.warn(`Unknown app found (${data.game_played_app_id})`);
+      presenceLogger.warn(`Unknown app found (${appid})`);
     } else {
       activeGame = {
-        appID: data.game_played_app_id,
+        appID: appid,
         presence: data.rich_presence,
         presenceString: data.rich_presence_string || null
       };

--- a/src/steam.ts
+++ b/src/steam.ts
@@ -89,7 +89,11 @@ user.on('error', async err => {
   logger.error(err);
 });
 
-user.on('appUpdate', async () => {
+user.on('ownershipCached', async () => {
+  await updateApps();
+});
+
+user.on('changelist', async () => {
   await updateApps();
 });
 
@@ -106,7 +110,6 @@ user.on('loggedOn', async details => {
   user.setPersona(SteamUser.EPersonaState.Online);
   user.setUIMode(SteamUser.EClientUIMode.Web);
   emitter.emit('loggedOn', details);
-  await updateApps();
 });
 
 user.on('steamGuard', async (domain, callback, lastCodeWrong) => {

--- a/src/view/app.vue
+++ b/src/view/app.vue
@@ -240,7 +240,7 @@ export default {
       return this.minimizeToTray ? remote.getCurrentWindow().hide() : remote.getCurrentWindow().close();
     },
     getActiveApp() {
-      return this.apps && this.activeGame && this.activeGame.appID ? this.apps.find(app => app.appid === this.activeGame.appID ) : null;
+      return this.apps && this.activeGame && this.activeGame.appID ? this.apps.get(this.activeGame.appID) : null;
     },
     updateSettings() {
       computedSettings.updateData(this);

--- a/src/view/app.vue
+++ b/src/view/app.vue
@@ -240,7 +240,7 @@ export default {
       return this.minimizeToTray ? remote.getCurrentWindow().hide() : remote.getCurrentWindow().close();
     },
     getActiveApp() {
-      return this.apps && this.activeGame ? this.apps.find(app => app.appid === this.activeGame.appID ) : null;
+      return this.apps && this.activeGame && this.activeGame.appID ? this.apps.find(app => app.appid === this.activeGame.appID ) : null;
     },
     updateSettings() {
       computedSettings.updateData(this);

--- a/src/view/app.vue
+++ b/src/view/app.vue
@@ -247,7 +247,7 @@ export default {
       settingsManager.update();
     },
     async logIn() {
-     this.$router.push('/home');
+     if (this.$router.currentRoute.path !== '/home') this.$router.push('/home');
     },
     abortAuth() {
       if (this.abortController)

--- a/src/view/components/DiscordHeader.vue
+++ b/src/view/components/DiscordHeader.vue
@@ -47,8 +47,8 @@
       </div>
       <div class="headerInfo">
         <div class="nameTag">
-          <span class="username">{{ user.username }}</span>
-          <span class="discriminator">#{{ user.discriminator }}</span>
+          <span class="username">{{ user.global_name || user.username }}</span>
+          <span v-if="user.discriminator !== '0'" class="discriminator">#{{ user.discriminator }}</span>
         </div>
         <div class="profileBadges">
           <!-- <div class="profileBadgeWrapper-1rGSsp">

--- a/src/view/components/GameListScrollItem.vue
+++ b/src/view/components/GameListScrollItem.vue
@@ -73,7 +73,7 @@
       />
       <div class="text">
         <!-- eslint-disable-next-line vue/no-v-html -->
-        <span v-if="source.searchName" :title="source.app.name" v-html="source.searchName" />
+        <span v-if="source.searchName" :title="source.app.name" v-html="searchSanitize(source.searchName)" />
         <span v-else :title="source.app.name">{{ source.app.name }}</span>
         <span v-if="source.metadata" class="subtitle" :title="`${source.metadata.version} - ${source.metadata.author.name}`">
           {{ source.metadata.version }} - {{ source.metadata.author.name }}
@@ -209,6 +209,9 @@ export default Vue.extend({
       this.hasQuery = !!query.trim();
       this.page.search(query);
       if (force) this.$refs.input.value = query;
+    },
+    searchSanitize(str: string) {
+      return str.replace(/<b>&<\/b><b>a<\/b><b>m<\/b><b>p<\/b><b>;<\/b>/g, '<b>&amp;</b>').replace(/<b>&<\/b><b>g<\/b><b>t<\/b><b>;<\/b>/g, '<b>&gt;</b>').replace(/<b>&<\/b><b>l<\/b><b>t<\/b><b>;<\/b>/g, '<b>&lt;</b>');
     }
   }
 });

--- a/src/view/components/NumberInput.vue
+++ b/src/view/components/NumberInput.vue
@@ -52,6 +52,10 @@ export default {
       type: Number,
       default: null,
     },
+    error: {
+      type: Boolean,
+      default: false
+    },
   },
   // @ts-ignore
   emits: ['input'],

--- a/src/view/components/PresenceSettingsModal.vue
+++ b/src/view/components/PresenceSettingsModal.vue
@@ -89,7 +89,7 @@ export default {
       return;
     }
     this.metadata = this.rpc.getMetadata();
-    this.app = steam.apps ? steam.apps.find(app => app.appid === this.appID) : {};
+    this.app = steam.apps ? steam.apps.get(this.appID) : {};
     this.dev = dev.currentPresences.has(this.appID);
     this.loading = false;
   },

--- a/src/view/components/SteamHeader.vue
+++ b/src/view/components/SteamHeader.vue
@@ -192,7 +192,7 @@ export default {
         flex-shrink 1
         flex-grow 1
         flex-direction column
-        justify-content flex-end
+        justify-content center
         margin-bottom -4px
         margin-right 4px
         .personanameandstatus_statusAndName_9U-hi

--- a/src/view/components/SteamHeader.vue
+++ b/src/view/components/SteamHeader.vue
@@ -202,8 +202,6 @@ export default {
           -webkit-app-region no-drag
           width 100%
           .ContextMenuButton
-            margin-top -4px
-            margin-bottom 4px
             opacity 0.5
             padding-top 2px
             padding-left 2px
@@ -226,7 +224,7 @@ export default {
           .personanameandstatus_playerName_1uxaf
             font-size 15px
             font-family "Motiva Sans", Arial, Helvetica, sans-serif
-            font-weight 300
+            font-weight 600
             transition color .94s ease-in-out
             text-shadow 1px 1px 4px #000
             white-space nowrap

--- a/src/view/components/TextInput.vue
+++ b/src/view/components/TextInput.vue
@@ -52,6 +52,10 @@ export default {
       type: String,
       default: null
     },
+    error: {
+      type: Boolean,
+      default: false
+    },
   },
   // @ts-ignore
   emits: ['input'],

--- a/src/view/developer.vue
+++ b/src/view/developer.vue
@@ -18,7 +18,7 @@
       <h4>Rich Presence Data</h4>
       <table>
         <tbody>
-          <tr v-for="row in activeGamePresence" :key="row">
+          <tr v-for="row in activeGamePresence" :key="row.key">
             <td>{{ row.key }}</td>
             <td>{{ row.value }}</td>
           </tr>

--- a/src/view/developer.vue
+++ b/src/view/developer.vue
@@ -127,7 +127,7 @@ export default {
     },
     reloadPresences() {
       const apps = this.$parent.apps || [];
-      this.currentPresences = dev.currentPresences.array().map(p => ({ ...p, app: apps.find(app => app.appid === p.metadata.app_id) }));
+      this.currentPresences = dev.currentPresences.array().map(p => ({ ...p, app: apps.get(p.metadata.app_id) }));
       this.hasConflicts = !!presenceManager.appIDsInFolder.filter(appID => dev.currentPresences.has(appID)).length
         || presenceManager.appIDsInFolder.map(id => rpc.rpcClients.has(id)).includes(false);
     },

--- a/src/view/games.vue
+++ b/src/view/games.vue
@@ -242,22 +242,25 @@ export default {
         this.updatesResults = null;
         return;
       }
+      function sanitize(str: string) {
+        return str.replace(/&/g, '&amp;').replace(/>/g, '&gt;').replace(/</g, '&lt;');
+      }
       query = query.replace(/&/g, '&amp;').replace(/>/g, '&gt;').replace(/</g, '&lt;');
       const installedMetadatas = this.getInstalledMetadatas();
       const updateMetadatas = presenceManager.availableUpdates.array();
       this.results = fuzzy.filter(query,
         installedMetadatas
-          .map(md => ({ ...md, safeName: md.name.replace(/&/g, '&amp;').replace(/>/g, '&gt;').replace(/</g, '&lt;') })),
+          .map(md => ({ ...md, safeName: sanitize(md.name) })),
         { pre: '<b>', post: '</b>', extract: md => md.safeName }
       );
       this.allGamesResults = this.apps ? fuzzy.filter(query,
         this.apps.values().toArray()
-          .map((app: { name: string }) => ({ ...app, safeName: app.name.replace(/&/g, '&amp;').replace(/>/g, '&gt;').replace(/</g, '&lt;') })),
+          .map((app: { name: string }) => ({ ...app, safeName: sanitize(app.name) })),
         { pre: '<b>', post: '</b>', extract: app => app.safeName }
       ) : null;
       this.updatesResults = fuzzy.filter(query,
         updateMetadatas
-          .map(md => ({ ...md, safeName: md.name.replace(/&/g, '&amp;').replace(/>/g, '&gt;').replace(/</g, '&lt;') })),
+          .map(md => ({ ...md, safeName: sanitize(md.name) })),
         { pre: '<b>', post: '</b>', extract: md => md.safeName }
       );
     }

--- a/src/view/games.vue
+++ b/src/view/games.vue
@@ -35,7 +35,7 @@ export default {
   },
   computed: {
     apps() {
-      return this.$parent.apps ? this.$parent.apps.slice(0).sort((a, b) => a.name.normalize().localeCompare(b.name.normalize())) : null;
+      return this.$parent.apps ? this.$parent.apps : null;
     },
     availableUpdates () {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -43,7 +43,7 @@ export default {
 
       let presences = presenceManager.availableUpdates.array().map(metadata => {
         const enabled = settings.get(`apps.${metadata.app_id}.enabled`, true);
-        const app = this.apps ? this.apps.find(app => app.appid === metadata.app_id) : null;
+        const app = this.apps ? this.apps.get(metadata.app_id) : null;
         return {
           id: `u-${metadata.app_id}`,
           type: 'game',
@@ -69,7 +69,7 @@ export default {
       else if (this.updatesResults !== null)
         presences = this.updatesResults.map(({ string, original: metadata }) => {
           const enabled = settings.get(`apps.${metadata.app_id}.enabled`, true);
-          const app = this.apps ? this.apps.find(app => app.appid === metadata.app_id) : null;
+          const app = this.apps ? this.apps(metadata.app_id) : null;
           return {
             id: `u-${metadata.app_id}`,
             type: 'game',
@@ -102,7 +102,7 @@ export default {
       let presences = presenceManager.appIDsInFolder.length ? presenceManager.appIDsInFolder.map(id => {
           const metadata = settings.get(`apps.${id}.metadata`);
           const enabled = settings.get(`apps.${id}.enabled`, true);
-          const app = this.apps ? this.apps.find(app => app.appid === id) : null;
+          const app = this.apps ? this.apps.get(id) : null;
           return {
             id: `i-${id}`,
             type: 'game',
@@ -123,7 +123,7 @@ export default {
           };
         }) : [{ id: 'installed-none', type: 'no-games', text: 'No presences installed.' }];
 
-      let allGames = this.apps ? this.apps.map(app => ({
+      let allGames = this.apps ? this.apps.values().toArray().map((app: { appid: number }) => ({
         id: `h-${app.appid}`, type: 'game', class: 'white', app
       })) : null;
       
@@ -136,7 +136,7 @@ export default {
       if (this.results !== null)
         presences = this.results.length ? this.results.map(({ string, original: metadata }) => {
           const enabled = settings.get(`apps.${metadata.app_id}.enabled`, true);
-          const app = this.apps ? this.apps.find(app => app.appid === metadata.app_id) : null;
+          const app = this.apps ? this.apps.get(metadata.app_id) : null;
           return {
             id: `i-${metadata.app_id}`,
             type: 'game',
@@ -251,8 +251,8 @@ export default {
         { pre: '<b>', post: '</b>', extract: md => md.safeName }
       );
       this.allGamesResults = this.apps ? fuzzy.filter(query,
-        this.apps
-          .map(app => ({ ...app, safeName: app.name.replace(/&/g, '&amp;').replace(/>/g, '&gt;').replace(/</g, '&lt;') })),
+        this.apps.values().toArray()
+          .map((app: { name: string }) => ({ ...app, safeName: app.name.replace(/&/g, '&amp;').replace(/>/g, '&gt;').replace(/</g, '&lt;') })),
         { pre: '<b>', post: '</b>', extract: app => app.safeName }
       ) : null;
       this.updatesResults = fuzzy.filter(query,

--- a/src/view/home.vue
+++ b/src/view/home.vue
@@ -46,11 +46,15 @@
     <span>Steemcord is <a @click="openLink('https://github.com/Steemcord/Steemcord')">open-source software</a> and does not send sensitive information to 3rd party sites or any installed presences.</span>
   </div>
   <div v-else id="homePage" class="page">
-    <h3>Hello, {{ username }}!</h3>
-    <a class="router-link" @click="logout">
-      <LogoutIcon />
-      <span>Log Out</span>
-    </a>
+    <div class="header">
+      <h3>Hello, {{ username }}!</h3>
+      <div>
+        <a class="router-link" @click="logout">
+          <LogoutIcon />
+          <span>Log Out</span>
+        </a>
+      </div>
+    </div>
     <br>
     <br>
     <SteamHeader
@@ -276,6 +280,9 @@ export default {
       text-decoration underline
       cursor pointer
 #homePage
+  .header
+    & > *
+      display inline-block
   .arrow
     width 100%
     height 50px

--- a/src/view/home.vue
+++ b/src/view/home.vue
@@ -155,7 +155,7 @@ export default {
       shell.openExternal(url);
     },
     getActiveApp() {
-      return this.$parent.apps && this.activeGame ? this.$parent.apps.find(app => app.appid === this.activeGame.appID ) : null;
+      return this.$parent.apps && this.activeGame && this.activeGame.appID ? this.$parent.apps.find(app => app.appid === this.activeGame.appID ) : null;
     },
     async login() {
       if (this.username) return;

--- a/src/view/home.vue
+++ b/src/view/home.vue
@@ -155,7 +155,7 @@ export default {
       shell.openExternal(url);
     },
     getActiveApp() {
-      return this.$parent.apps && this.activeGame && this.activeGame.appID ? this.$parent.apps.find(app => app.appid === this.activeGame.appID ) : null;
+      return this.$parent.apps && this.activeGame && this.activeGame.appID ? this.$parent.apps.get(this.activeGame.appID) : null;
     },
     async login() {
       if (this.username) return;

--- a/src/view/presences.vue
+++ b/src/view/presences.vue
@@ -34,14 +34,17 @@ export default {
       return this.$parent.apps ? this.$parent.apps.slice(0).sort((a, b) => a.name.normalize().localeCompare(b.name.normalize())) : null;
     },
     scrollItems () {
+      const header = { id: 'presences-header', type: 'header', text: 'Presences', refreshButton: true };
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       ((_) => this.ticker)();
 
       if (this.loading || !this.metadatas) return [
+          { ...header, refreshButton: false },
           { id: 'loading-status', type: 'no-games',
             text: 'Loading...' }
         ];
       else if (this.errorText) return [
+          { ...header, refreshButton: false },
           { id: 'loading-status', type: 'no-games',
             text: this.errorText },
           { id: 'loading-reload', type: 'reload-btn', text: 'Refresh' }
@@ -96,7 +99,7 @@ export default {
       }
 
       return [
-        { id: 'presences-header', type: 'header', text: 'Presences', refreshButton: true },
+        header,
         { id: 'search', type: 'search' },
         ...presences
       ];

--- a/src/view/presences.vue
+++ b/src/view/presences.vue
@@ -31,7 +31,7 @@ export default {
   },
   computed: {
     apps() {
-      return this.$parent.apps ? this.$parent.apps.slice(0).sort((a, b) => a.name.normalize().localeCompare(b.name.normalize())) : null;
+      return this.$parent.apps ? this.$parent.apps : null;
     },
     scrollItems () {
       const header = { id: 'presences-header', type: 'header', text: 'Presences', refreshButton: true };
@@ -51,7 +51,7 @@ export default {
         ];
       
       let presences = this.metadatas.length ? this.metadatas.map(metadata => {
-          const app = this.apps ? this.apps.find(app => app.appid === metadata.app_id) : null;
+          const app = this.apps ? this.apps.get(metadata.app_id) : null;
           return {
             id: `s-${metadata.app_id}`,
             type: 'game',
@@ -75,7 +75,7 @@ export default {
 
       if (this.results) {
         presences = this.results.length ? this.results.map(({ string, original: metadata }) => {
-          const app = this.apps ? this.apps.find(app => app.appid === metadata.app_id) : null;
+          const app = this.apps ? this.apps.get(metadata.app_id) : null;
           return {
             id: `s-${metadata.app_id}`,
             type: 'game',


### PR DESCRIPTION
First batch of fixes! How exciting! Reasoning for each commit is below.

---

> Fix warning about missing property

Both text and number fields use an `error` property, which was not actually defined. This could be useful in the future, so rather than removing the usage, define the property.

> Fix uncaught error about navigating to the current page

Vue Router didn't like navigating to the current page. Strange it doesn't handle this on its own, but less uncaught errors the better.

> Make logout button smaller

I hit this button **way** too many times by accident when attempt to refocus the window, requiring Steam Guard again every time. 100% user error, but unpleasant. I wouldn't mind also adding a confirmation dialog, but this is good enough.

Before/After:

![image](https://github.com/user-attachments/assets/c688c911-90fa-4838-bdba-4bad25c0c87a)

![image](https://github.com/user-attachments/assets/536baf1a-47a7-4e4a-9cf6-1e18f70262bc)

> Cut down excessive game list reloading

The full game list was being re-fetched from Steam every time a singular game was changed. For some reason in my library, this happens for over 10 games every minute. This meant the full list of games was re-fetched ~10 times a minute, rather than once.

Ideally, `updateApps()` could also only modify the games that were changed, rather than re-fetching the list, as the event we listen for provides the updated object, but that can be done later.

> Fix alignment of text in Steam header

This makes the Steam header appear more similar to the real Steam display.

Before/After:

![image](https://github.com/user-attachments/assets/769b97a7-aeb2-4487-b128-04d4a531a1d7)

![image](https://github.com/user-attachments/assets/e44d3205-79c5-4179-b3df-dae5fe09c871)

Steam reference:

![image](https://github.com/user-attachments/assets/6cec5f75-2d08-48d8-8f42-2152b1367929)

> Fix invalid unique key in Dev Presence data list

The list of data items for the current presence had an object set as the key, which meant every row had the same key.

> Show Presences heading while loading

Consistent with other pages.

> Don't search for active game when there is no active game

`activeGame` is sometimes set to an object with a game ID of `0`, rather than `null` itself. For a large enough game library, this was causing navigating back and forth from Presences to Games to take an unusual amount of time.

Ideally, we shouldn't have to filter through the `activeGame` list on navigation, rather when the game changes, but that's a bigger task for later.

> Fix error opening context menu too early; Fix context menu not opening on first click

Turns out Tray icons are weird. This fixes two specific cases I ran into on Windows.

> Use modern Discord display name if available

Discord switched from discriminators to unique usernames, so we now show the display name instead, if available.

![image](https://github.com/user-attachments/assets/67885452-c08f-4f2e-b4f4-934d8e9b9e81)

> Refactor apps array to a Map for performance

This improves performance for users with large amounts of games, as sorting occurred every time the user navigated to either Presences or Games, and the whole array had to be searched in various locations.