### PR TITLE
Display Discord Presence assets in Preview

### DIFF
--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -16,6 +16,7 @@ export const emitter = new EventEmitter();
 let lastPresenceSet: number = null;
 let lastPresenceActive: number = null;
 export let lastPresence: PresenceData = null;
+export let lastPresenceAssetIDs: { large_image: string, small_image: string, client: string } = null;
 
 export interface PresenceMetadata {
   app_id: number;
@@ -141,14 +142,20 @@ export class RPCClient {
 
     this.client
       .setActivity(presenceData)
-      .catch(e => logger.error('Activity Set Error', e));
-
-    this.currentPresence = presenceData;
-    this.presence.currentPresence = presenceData;
-    lastPresenceSet = this.appID;
-    lastPresence = presenceData;
-    emitter.emit('update');
-    logger.info(`Activity Updated (${this.presence.clientID}, ${this.appID})`);
+      .then(r => {
+        if (r.assets) {
+          lastPresenceAssetIDs = { ...r.assets, client: this.presence.clientID };
+        } else lastPresenceAssetIDs = null;
+      })
+      .catch(e => logger.error('Activity Set Error', e))
+      .finally(() => {
+        this.currentPresence = presenceData;
+        this.presence.currentPresence = presenceData;
+        lastPresenceSet = this.appID;
+        lastPresence = presenceData;
+        emitter.emit('update');
+        logger.info(`Activity Updated (${this.presence.clientID}, ${this.appID})`);
+      });
   }
 
   clearActivity(): void {
@@ -157,6 +164,7 @@ export class RPCClient {
     if (lastPresenceSet === this.appID) {
       lastPresenceSet = null;
       lastPresence = null;
+      lastPresenceAssetIDs = null;
       emitter.emit('update');
     }
 

--- a/src/view/app.vue
+++ b/src/view/app.vue
@@ -170,6 +170,7 @@ export default {
       userName: steam.userName,
       activeGame: steam.activeGame,
       currentPresence: rpc.lastPresence,
+      presenceAssetIDs: rpc.lastPresenceAssetIDs,
       discordUser: presenceManager.rpc ? presenceManager.rpc.user : null,
       nextUpdateAvailable: updater.updateAvailable,
       ...computedSettings.fillData()
@@ -201,7 +202,10 @@ export default {
       this.discordStatus = 3;
       this.discordUser = null;
     };
-    const rpcBind = () => this.currentPresence = rpc.lastPresence;
+    const rpcBind = () => {
+      this.currentPresence = rpc.lastPresence;
+      this.presenceAssetIDs = rpc.lastPresenceAssetIDs;
+    };
     const updateBind = ver => this.nextUpdateAvailable = ver;
     const debugBind = message => console.log('[steam]', message);
 

--- a/src/view/components/DiscordHeader.vue
+++ b/src/view/components/DiscordHeader.vue
@@ -84,13 +84,13 @@
               v-tippy="{ arrow: true }"
               class="assetsLargeImage"
               :content="richpresence.largeImageText"
-              :src="largeImageURL || (metadata ? metadata.icon : null ) || (app ? app.img_icon_url : null ) || largeImagePlaceholder"
+              :src="largeImageUrl || (metadata ? metadata.icon : null ) || (app ? app.img_icon_url : null ) || largeImagePlaceholder"
               :class="richpresence.smallImageKey ? 'maskLargeImage' : ''"
             >
             <img
               v-else
               class="assetsLargeImage"
-              :src="largeImageURL || (metadata ? metadata.icon : null ) || (app ? app.img_icon_url : null ) || largeImagePlaceholder"
+              :src="largeImageUrl || (metadata ? metadata.icon : null ) || (app ? app.img_icon_url : null ) || largeImagePlaceholder"
               :class="richpresence.smallImageKey ? 'maskLargeImage' : ''"
             >
             <img
@@ -98,12 +98,12 @@
               v-tippy="{ arrow: true }"
               :content="richpresence.smallImageText"
               class="assetsSmallImage"
-              :src="smallImageURL || smallImagePlaceholder"
+              :src="smallImageUrl || smallImagePlaceholder"
             >
             <img
               v-else-if="richpresence.smallImageKey"
               class="assetsSmallImage"
-              :src="smallImageURL || smallImagePlaceholder"
+              :src="smallImageUrl || smallImagePlaceholder"
             >
           </div>
           <div class="contentImagesProfile">
@@ -164,11 +164,11 @@ export default {
       type: String,
       default: 'normal'
     },
-    largeImageURL: {
+    largeImageUrl: {
       type: String,
       default: ''
     },
-    smallImageURL: {
+    smallImageUrl: {
       type: String,
       default: ''
     },

--- a/src/view/home.vue
+++ b/src/view/home.vue
@@ -75,6 +75,8 @@
       :type="isActiveGame && currentPresence ? 'playing' : 'normal'"
       :richpresence="isActiveGame ? currentPresence : null"
       :app="isActiveGame ? getActiveApp() : null"
+      :large-image-url="presenceAssetIDs && presenceAssetIDs.large_image ? `https://cdn.discordapp.com/app-assets/${presenceAssetIDs.client}/${presenceAssetIDs.large_image}.png` : null"
+      :small-image-url="presenceAssetIDs && presenceAssetIDs.small_image ? `https://cdn.discordapp.com/app-assets/${presenceAssetIDs.client}/${presenceAssetIDs.small_image}.png` : null"
     />
     <a
       v-if="isActiveGame && (activeGame.presenceString || activeGame.presence.length) && !currentPresence"
@@ -145,6 +147,9 @@ export default {
     },
     currentPresence() {
       return this.$parent.currentPresence;
+    },
+    presenceAssetIDs() {
+      return this.$parent.presenceAssetIDs;
     },
     steamID() {
       return this.username ? steam.steamID : null;

--- a/src/view/home.vue
+++ b/src/view/home.vue
@@ -75,8 +75,8 @@
       :type="isActiveGame && currentPresence ? 'playing' : 'normal'"
       :richpresence="isActiveGame ? currentPresence : null"
       :app="isActiveGame ? getActiveApp() : null"
-      :large-image-url="presenceAssetIDs && presenceAssetIDs.large_image ? `https://cdn.discordapp.com/app-assets/${presenceAssetIDs.client}/${presenceAssetIDs.large_image}.png` : null"
-      :small-image-url="presenceAssetIDs && presenceAssetIDs.small_image ? `https://cdn.discordapp.com/app-assets/${presenceAssetIDs.client}/${presenceAssetIDs.small_image}.png` : null"
+      :large-image-url="parseImageKey(presenceAssetIDs.large_image)"
+      :small-image-url="parseImageKey(presenceAssetIDs.small_image)"
     />
     <a
       v-if="isActiveGame && (activeGame.presenceString || activeGame.presence.length) && !currentPresence"
@@ -161,6 +161,12 @@ export default {
     },
     getActiveApp() {
       return this.$parent.apps && this.activeGame && this.activeGame.appID ? this.$parent.apps.get(this.activeGame.appID) : null;
+    },
+    parseImageKey(imageKey: string) {
+      if (!this.$parent.presenceAssetIDs || !imageKey) return null;
+      if (imageKey.startsWith('mp:')) return `https://media.discordapp.net/${imageKey.slice(3)}`;
+      else `https://cdn.discordapp.com/app-assets/${this.$parent.presenceAssetIDs.client}/${imageKey}.png`;
+      return null;
     },
     async login() {
       if (this.username) return;

--- a/src/view/home.vue
+++ b/src/view/home.vue
@@ -75,8 +75,8 @@
       :type="isActiveGame && currentPresence ? 'playing' : 'normal'"
       :richpresence="isActiveGame ? currentPresence : null"
       :app="isActiveGame ? getActiveApp() : null"
-      :large-image-url="parseImageKey(presenceAssetIDs.large_image)"
-      :small-image-url="parseImageKey(presenceAssetIDs.small_image)"
+      :large-image-url="presenceAssetIDs ? parseImageKey(presenceAssetIDs.large_image) : null"
+      :small-image-url="presenceAssetIDs ? parseImageKey(presenceAssetIDs.small_image) : null"
     />
     <a
       v-if="isActiveGame && (activeGame.presenceString || activeGame.presence.length) && !currentPresence"
@@ -165,8 +165,7 @@ export default {
     parseImageKey(imageKey: string) {
       if (!this.$parent.presenceAssetIDs || !imageKey) return null;
       if (imageKey.startsWith('mp:')) return `https://media.discordapp.net/${imageKey.slice(3)}`;
-      else `https://cdn.discordapp.com/app-assets/${this.$parent.presenceAssetIDs.client}/${imageKey}.png`;
-      return null;
+      else return `https://cdn.discordapp.com/app-assets/${this.$parent.presenceAssetIDs.client}/${imageKey}.png`;
     },
     async login() {
       if (this.username) return;


### PR DESCRIPTION
This caches the Asset IDs and the Client ID for the presence, and passes a valid Discord CDN url to the Discord header.

I'm not 100% sold on the changes to `rpcBind`, so I'm open to feedback on a better flow.

Also renamed the props because ESLint wanted to hyphenate `u-r-l`.

![image](https://github.com/user-attachments/assets/6cb76794-dbd7-4ba1-a023-caf0a98facea)

![image](https://github.com/user-attachments/assets/2eabc59e-b935-4a14-8ec5-02e44b0906eb)
